### PR TITLE
Allow to work with custom Capybara drivers that use Capybara::Selenium::Driver

### DIFF
--- a/lib/show_me_the_cookies.rb
+++ b/lib/show_me_the_cookies.rb
@@ -45,7 +45,19 @@ private
   end
 
   def current_driver_adapter
-    adapter = adapters[Capybara.current_driver] || raise("Unsupported driver #{driver}, use one of #{drivers.keys}")
+    adapter = adapters[Capybara.current_driver]
+    if adapter.nil?
+      if driver_uses_selenium?
+        adapter = adapters[:selenium]
+      else
+        raise("Unsupported driver #{Capybara.current_driver}, use one of #{Capybara.drivers.keys}")
+      end
+    end
     adapter.new(Capybara.current_session.driver)
+  end
+
+  def driver_uses_selenium?
+    driver = Capybara.drivers[Capybara.current_driver].call(nil)
+    driver.is_a?(Capybara::Selenium::Driver)
   end
 end

--- a/spec/request/custom_spec.rb
+++ b/spec/request/custom_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'shared_examples_for_api'
+
+describe "Custom Webdriver", :type => :request do
+  before(:all) do
+    Capybara.register_driver :custom do |app|
+      Capybara::Selenium::Driver.new(app, :resynchronize => true)
+    end
+  end
+  before(:each) do
+    Capybara.current_driver = :custom
+  end
+
+  describe "the testing rig" do
+    it "should load the sinatra app" do
+      visit '/'
+      page.should have_content("Cookie setter ready")
+    end
+  end
+
+  it_behaves_like "the API"
+end


### PR DESCRIPTION
Thanks for this gem!

In the project we're using it, we're also registering our own custom Capybara drivers that are using Selenium and set different options to use a remote browser or set the :resynchronize option to true for instance.

i.e.:

```
Capybara.register_driver :chrome do |app|
    Capybara::Selenium::Driver.new(app, :browser => chrome, :resynchronize => true)
end
[...]
Capybara.current_driver = :chrome
```

The goal of this pull request is to be able to use show_me_the_cookies with those custom drivers.
