### PR TITLE
Fix issue #9 unsupported driver error

### DIFF
--- a/lib/show_me_the_cookies.rb
+++ b/lib/show_me_the_cookies.rb
@@ -50,7 +50,7 @@ private
       if driver_uses_selenium?
         adapter = adapters[:selenium]
       else
-        raise("Unsupported driver #{Capybara.current_driver}, use one of #{Capybara.drivers.keys}")
+        raise("Unsupported driver #{Capybara.current_driver}, use one of #{adapters.keys}")
       end
     end
     adapter.new(Capybara.current_session.driver)


### PR DESCRIPTION
If the driver that I use is not supported, show the supported drivers by show_me_the_cookies, instead of the list of Capybara drivers.
