### PR TITLE
Rspec 3 compatibility

### DIFF
--- a/show_me_the_cookies.gemspec
+++ b/show_me_the_cookies.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_dependency('capybara', '~> 2.0')
   s.add_development_dependency 'rake' # for releases
-  s.add_development_dependency 'rspec' # for testing
+  s.add_development_dependency 'rspec', '~> 3.0' # for testing
   s.add_development_dependency 'sinatra' # for testing
   s.add_development_dependency 'poltergeist' # for testing
   s.add_development_dependency 'selenium-webdriver' # removed from capy2 deps

--- a/spec/drivers/poltergeist_spec.rb
+++ b/spec/drivers/poltergeist_spec.rb
@@ -10,7 +10,7 @@ describe "Poltergeist", :type => :feature do
   describe "the testing rig" do
     it "should load the sinatra app" do
       visit '/'
-      page.should have_content("Cookie setter ready")
+      expect(page).to have_content("Cookie setter ready")
     end
   end
 

--- a/spec/drivers/rack-test_spec.rb
+++ b/spec/drivers/rack-test_spec.rb
@@ -9,7 +9,7 @@ describe "RackTest", :type => :feature do
   describe "the testing rig" do
     it "should load the sinatra app" do
       visit '/'
-      page.should have_content("Cookie setter ready")
+      expect(page).to have_content("Cookie setter ready")
     end
   end
 

--- a/spec/drivers/selenium_spec.rb
+++ b/spec/drivers/selenium_spec.rb
@@ -9,7 +9,7 @@ describe "Selenium Webdriver", :type => :feature do
   describe "the testing rig" do
     it "should load the sinatra app" do
       visit '/'
-      page.should have_content("Cookie setter ready")
+      expect(page).to have_content("Cookie setter ready")
     end
   end
 

--- a/spec/drivers/webkit_spec.rb
+++ b/spec/drivers/webkit_spec.rb
@@ -10,7 +10,7 @@ describe "Webkit", :type => :feature do
   describe "the testing rig" do
     it "should load the sinatra app" do
       visit '/'
-      page.should have_content("Cookie setter ready")
+      expect(page).to have_content("Cookie setter ready")
     end
   end
 

--- a/spec/shared_examples_for_api.rb
+++ b/spec/shared_examples_for_api.rb
@@ -4,21 +4,21 @@ shared_examples "the API" do
     describe "get_me_the_cookie" do
       it "returns the cookie hash" do
         visit '/set/foo/bar'
-        get_me_the_cookie('foo').should include(:name => "foo", :value => "bar", :expires => nil, :secure => false)
+        expect(get_me_the_cookie('foo')).to include(:name => "foo", :value => "bar", :expires => nil, :secure => false)
       end
     end
 
     it "returns nil for cookies that do not exist" do
-      get_me_the_cookie('some_unset_cookie').should be_nil
+      expect(get_me_the_cookie('some_unset_cookie')).to be_nil
     end
 
     describe "get_me_the_cookies" do
       it "returns an array of standardised cookie hashes" do
         visit '/set/foo/bar'
-        page.should have_content("Setting foo=bar")
-        get_me_the_cookies.first.should include(:name => "foo", :value => "bar", :expires => nil, :secure => false)
+        expect(page).to have_content("Setting foo=bar")
+        expect(get_me_the_cookies.first).to include(:name => "foo", :value => "bar", :expires => nil, :secure => false)
         visit '/set/myopic/mice'
-        get_me_the_cookies.length.should be(2)
+        expect(get_me_the_cookies.length).to be(2)
       end
     end
   end
@@ -27,7 +27,7 @@ shared_examples "the API" do
     describe "show_me_the_cookie" do
       it "inspects the cookie hash" do
         visit '/set/foo/bar'
-        should_receive(:puts).with("foo: "+get_me_the_cookie('foo').inspect)
+        expect($stdout).to receive(:puts).with("foo: "+get_me_the_cookie('foo').inspect)
         show_me_the_cookie('foo')
       end
     end
@@ -36,12 +36,11 @@ shared_examples "the API" do
       it "returns a string representation of the get_me_the_cookies hash" do
         visit '/set/foo/bar'
         visit '/set/myopic/mice'
-        should_receive(:puts).with("Cookies: "+get_me_the_cookies.inspect)
+        expect($stdout).to receive(:puts).with("Cookies: "+get_me_the_cookies.inspect)
         show_me_the_cookies
       end
     end
   end
-
 
   describe "for manipulating cookies" do
     describe "delete_cookie(cookie_name)" do
@@ -71,7 +70,7 @@ shared_examples "the API" do
         create_cookie("choc", "milk")
         visit "/get/choc"
         cookies_should_contain("choc", "milk")
-        page.should have_content("Got cookie choc=milk")
+        expect(page).to have_content("Got cookie choc=milk")
       end
 
       it "accepts symbols" do
@@ -80,7 +79,7 @@ shared_examples "the API" do
         create_cookie(:choc, :milk)
         visit "/get/choc"
         cookies_should_contain("choc", "milk")
-        page.should have_content("Got cookie choc=milk")
+        expect(page).to have_content("Got cookie choc=milk")
       end
 
       it "creates a cookie with path and domain" do
@@ -90,14 +89,14 @@ shared_examples "the API" do
         cookies_should_contain("choc", "milk")
 
         visit("/get/choc")
-        page.should have_content("Got cookie choc=milk")
+        expect(page).to have_content("Got cookie choc=milk")
 
         visit '/set_with_domain/choc/doublemilk'
         cookies_should_contain("choc", "doublemilk")
         cookies_should_not_contain('choc', 'milk')
 
         visit("/get/choc")
-        page.should have_content("Got cookie choc=doublemilk")
+        expect(page).to have_content("Got cookie choc=doublemilk")
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,12 +15,12 @@ def cookies_should_contain(key, value)
   key_present = get_me_the_cookies.any? {|c| c[:name] == key}
   value_present = get_me_the_cookies.any? {|c| c[:value] == value}
   msg = "Cookie not found: #{key}=#{value} in #{get_me_the_cookies.inspect}"
-  (key_present and value_present).should be_true, msg
+  expect(key_present && value_present).to be_truthy, msg
 end
 
 def cookies_should_not_contain(key, value)
   key_present = get_me_the_cookies.any? {|c| c[:name] == key}
   value_present = get_me_the_cookies.any? {|c| c[:value] == value}
   msg = "Unwanted cookie found: #{key}=#{value} in #{get_me_the_cookies.inspect}"
-  (key_present and value_present).should be_false, msg
+  expect(key_present && value_present).to be_falsey, msg
 end


### PR DESCRIPTION
This pull request makes specs compatible with RSpec 3. 

Turns out the specs will fail in a fresh clone since the RSpec version is not declared and bundler will install RSpec 3.0. You could declare the dependency on RSpec 2 but I figured it would be useful to upgrade.