### PR TITLE
Add rack-test cookie support for reading httponly value

### DIFF
--- a/lib/show_me_the_cookies/adapters/rack_test.rb
+++ b/lib/show_me_the_cookies/adapters/rack_test.rb
@@ -42,12 +42,17 @@ private
     cookie_jar.instance_variable_get(:@cookies)
   end
 
+  def httponly?(cookie)
+    (cookie.instance_variable_get(:@options) || {}).has_key?("HttpOnly")
+  end
+
   def _translate_cookie(cookie)
     {:name => cookie.name,
     :domain => cookie.domain,
     :value => cookie.value,
     :expires => cookie.expires,
     :path => cookie.path,
-    :secure => cookie.secure?}
+    :secure => cookie.secure?,
+    :httponly => httponly?(cookie)}
   end
 end

--- a/spec/app/set_cookie.rb
+++ b/spec/app/set_cookie.rb
@@ -32,3 +32,8 @@ get '/set_with_domain/:key/:value' do
   response.set_cookie params[:key], {:value => params[:value], :path => '/', :domain => '.lvh.me'}
   "Setting #{params[:key]}=#{params[:value]}"
 end
+
+get '/set_httponly/:key/:value' do
+  response.set_cookie params[:key], {:value => params[:value], :path => '/', :httponly => true}
+  "Setting httponly #{params[:key]}=#{params[:value]}"
+end

--- a/spec/drivers/poltergeist_spec.rb
+++ b/spec/drivers/poltergeist_spec.rb
@@ -14,5 +14,13 @@ describe "Poltergeist", :type => :feature do
     end
   end
 
+  describe "get_me_the_cookie" do
+    it "reads httponly option" do
+      visit "/set_httponly/foo/bar"
+      get_me_the_cookie('foo').should include(:name => "foo", :value => "bar", :httponly => true)
+    end
+  end
+
   it_behaves_like "the API"
+
 end

--- a/spec/drivers/rack-test_spec.rb
+++ b/spec/drivers/rack-test_spec.rb
@@ -13,5 +13,13 @@ describe "RackTest", :type => :feature do
     end
   end
 
+  describe "get_me_the_cookie" do
+    it "reads httponly option" do
+      visit "/set_httponly/foo/bar"
+      get_me_the_cookie('foo').should include(:name => "foo", :value => "bar", :httponly => true)
+    end
+  end
+
   it_behaves_like "the API"
+
 end


### PR DESCRIPTION
Matches poltergeist api with httponly flag by reading `Rack::Test::Cookie` httponly options value.