### PR TITLE
Add support for Capybara-Webkit 1.6.0

### DIFF
--- a/lib/show_me_the_cookies/adapters/webkit.rb
+++ b/lib/show_me_the_cookies/adapters/webkit.rb
@@ -1,7 +1,6 @@
 module ShowMeTheCookies
   class Webkit
     def initialize(driver)
-      @browser = driver.browser
       @driver = driver
     end
 
@@ -23,16 +22,16 @@ module ShowMeTheCookies
     # Since QTWebkit doesn't seem to offer deletion, clearing all and re-setting the rest seems to be it
     def delete_cookie(name)
       old_cookies = cookies
-      @browser.clear_cookies
+      @driver.clear_cookies
       old_cookies.each do |cookie|
-        @browser.set_cookie(cookie) unless cookie.name == name.to_s
+        @driver.set_cookie(cookie) unless cookie.name == name.to_s
       end
     end
 
     def create_cookie(name, value, options)
       host = options.delete(:domain) || (Capybara.app_host ? URI(Capybara.app_host).host : '127.0.0.1')
       puts "Webkit create_cookie options not supported: #{options.inspect}" if options && (options != {})
-      @browser.set_cookie("#{name}=#{value}; domain=#{host}")
+      @driver.set_cookie("#{name}=#{value}; domain=#{host}")
     end
 
     private
@@ -43,7 +42,7 @@ module ShowMeTheCookies
     end
 
     def cookies
-      @browser.get_cookies.map { |c| WEBrick::Cookie.parse_set_cookie(c) }
+      cookie_jar.send("cookies")
     end
 
     def translate(cookie)

--- a/spec/drivers/webkit_spec.rb
+++ b/spec/drivers/webkit_spec.rb
@@ -2,10 +2,13 @@ require 'spec_helper'
 require 'shared_examples_for_api'
 require 'capybara-webkit'
 
+Capybara::Webkit.configure do |config|
+  config.allow_url("subdomain.lvh.me")
+end
+
 describe 'Webkit', type: :feature do
   before(:each) do
     Capybara.current_driver = :webkit
-    page.driver.allow_url('subdomain.lvh.me')
   end
 
   describe 'the testing rig' do


### PR DESCRIPTION
Due to recent changes in Capybara Webkit [1.6.0](https://github.com/thoughtbot/capybara-webkit/releases/tag/v1.6.0) and as mentioned in the latest [NEWS](https://github.com/thoughtbot/capybara-webkit/blob/master/NEWS.md):
* Calling `browser` directly is deprecated
* Calling the `page.allow_url` method is being deprecated in favor of a [configuration block](https://github.com/thoughtbot/capybara-webkit#configuration)