### PR TITLE
Add support for capybara-mechanize

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Some helpers for poking around at your Capybara driven browser's cookies in integration tests. Should have been called capybara-cookies if you go by the [rubygems naming guide](http://guides.rubygems.org/name-your-gem/).
 
-Provides drivers for rack-test, [selenium-webdriver](https://rubygems.org/gems/selenium-webdriver)),  [Poltergeist](https://github.com/teampoltergeist/poltergeist) (PhantomJS) and [capybara-webkit](https://github.com/thoughtbot/capybara-webkit).
+Provides drivers for rack-test, [selenium-webdriver](https://rubygems.org/gems/selenium-webdriver)), [Poltergeist](https://github.com/teampoltergeist/poltergeist) (PhantomJS), [capybara-webkit](https://github.com/thoughtbot/capybara-webkit) and [capybara-mechanize](https://github.com/jeroenvandijk/capybara-mechanize).
 You may add new drivers for your application by implementing an adapter class and calling ShowMeTheCookies.register_adapter in your test code (e.g. a spec/support file).
 
 ## API
@@ -111,7 +111,7 @@ Install by loading the gem and adding the following to your stepdefs or support 
     end
 
 
-### Installing your own drivers
+## Installing your own drivers
 
 Register your adapter class in your test setup after loading the library.
 

--- a/lib/show_me_the_cookies.rb
+++ b/lib/show_me_the_cookies.rb
@@ -4,6 +4,7 @@ module ShowMeTheCookies
   require 'show_me_the_cookies/adapters/selenium'
   require 'show_me_the_cookies/adapters/selenium_chrome'
   require 'show_me_the_cookies/adapters/webkit'
+  require 'show_me_the_cookies/adapters/mechanize'
 
   @adapters = {}
   class << self
@@ -23,6 +24,7 @@ module ShowMeTheCookies
   register_adapter(:rack_test, ShowMeTheCookies::RackTest)
   register_adapter(:poltergeist, ShowMeTheCookies::Poltergeist)
   register_adapter(:webkit, ShowMeTheCookies::Webkit)
+  register_adapter(:mechanize, ShowMeTheCookies::Mechanize)
 
   # puts a string summary of the cookie
   def show_me_the_cookie(cookie_name)

--- a/lib/show_me_the_cookies/adapters/mechanize.rb
+++ b/lib/show_me_the_cookies/adapters/mechanize.rb
@@ -1,0 +1,60 @@
+module ShowMeTheCookies
+  class Mechanize
+    def initialize(mechanize_driver)
+      @mechanize_driver = mechanize_driver
+    end
+
+    def get_me_the_cookie(cookie_name)
+      found = cookies.select {|c| c.name == cookie_name}
+      found.empty? ? nil : _translate_cookie(found.first)
+    end
+
+    def get_me_the_cookies
+      cookies.map {|c| _translate_cookie(c) }
+    end
+
+    def expire_cookies
+      cookies.reject! do |existing_cookie|
+        # See http://j-ferguson.com/testing/bdd/hacking-capybara-cookies/
+        # catch session cookies/no expiry (nil) and past expiry (true)
+        existing_cookie.expired? != false
+      end
+    end
+
+    def delete_cookie(cookie_name)
+      cookies.reject! do |existing_cookie|
+        existing_cookie.name.downcase == cookie_name.to_s
+      end
+    end
+
+    def create_cookie(name, value, options)
+      cookie_raw = "#{name}=#{Rack::Utils.escape(value)}"
+      (cookie_raw = "#{cookie_raw}; domain=#{options[:domain]}") if options.has_key?(:domain)
+      (cookie_raw = "#{cookie_raw}; path=#{options[:path]}")     if options.has_key?(:path)
+      cookie_jar.merge(cookie_raw)
+    end
+
+  private
+    def cookie_jar
+      @mechanize_driver.browser.current_session.instance_variable_get(:@rack_mock_session).cookie_jar
+    end
+
+    def cookies
+      cookie_jar.instance_variable_get(:@cookies)
+    end
+
+    def httponly?(cookie)
+      (cookie.instance_variable_get(:@options) || {}).has_key?("HttpOnly")
+    end
+
+    def _translate_cookie(cookie)
+      {:name => cookie.name,
+      :domain => cookie.domain,
+      :value => cookie.value,
+      :expires => cookie.expires,
+      :path => cookie.path,
+      :secure => cookie.secure?,
+      :httponly => httponly?(cookie)}
+    end
+  end
+end

--- a/show_me_the_cookies.gemspec
+++ b/show_me_the_cookies.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'selenium-webdriver' # removed from capy2 deps
   s.add_development_dependency 'chromedriver-helper' # chromedriver installer
   s.add_development_dependency 'capybara-webkit' # for testing
+  s.add_development_dependency 'capybara-mechanize' # for testing
 end

--- a/spec/drivers/mechanize_spec.rb
+++ b/spec/drivers/mechanize_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+require 'shared_examples_for_api'
+require 'capybara/mechanize'
+
+Capybara::Mechanize.local_hosts << "subdomain.lvh.me"
+
+describe 'Mechanize', type: :feature do
+  around(:each) do |example|
+    # mechanize will think that our app is remote if we set Capybara.app_host, which is not what we want
+    app_host, Capybara.app_host = Capybara.app_host, nil
+    example.run
+    Capybara.app_host = app_host
+  end
+
+  before(:each) do
+    Capybara.current_driver = :mechanize
+  end
+
+  describe 'the testing rig' do
+    it 'should load the sinatra app' do
+      visit '/'
+      expect(page).to have_content('Cookie setter ready')
+    end
+  end
+
+  describe 'get_me_the_cookie' do
+    it 'reads httponly option' do
+      visit '/set_httponly/foo/bar'
+      expect(get_me_the_cookie('foo')).to include(
+        name: 'foo', value: 'bar', httponly: true
+      )
+    end
+  end
+
+  it_behaves_like 'the API'
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ end
 
 Capybara.server_port = 36363
 Capybara.app_host = "http://subdomain.lvh.me:#{Capybara.server_port}"
+Capybara.default_host = Capybara.app_host
 
 def cookies_should_contain(key, value)
   key_present = get_me_the_cookies.any? {|c| c[:name] == key}


### PR DESCRIPTION
Only works for cookies for local requests, not for remote requests. So, `Capybara.app_host` needs to be `nil` and `Capybara.default_host` should be set instead (if you need that).
