### PR TITLE
register Webkit adapter for :webkit_debug

### DIFF
--- a/lib/show_me_the_cookies.rb
+++ b/lib/show_me_the_cookies.rb
@@ -23,6 +23,7 @@ module ShowMeTheCookies
   register_adapter(:rack_test, ShowMeTheCookies::RackTest)
   register_adapter(:poltergeist, ShowMeTheCookies::Poltergeist)
   register_adapter(:webkit, ShowMeTheCookies::Webkit)
+  register_adapter(:webkit_debug, ShowMeTheCookies::Webkit)
 
   # puts a string summary of the cookie
   def show_me_the_cookie(cookie_name)


### PR DESCRIPTION
Allows using the driver :webkit_debug, which is just a verbose version of :webkit