### PR TITLE
Support phantomjs adapter

### DIFF
--- a/lib/show_me_the_cookies.rb
+++ b/lib/show_me_the_cookies.rb
@@ -22,6 +22,7 @@ module ShowMeTheCookies
   register_adapter(:selenium_chrome, ShowMeTheCookies::SeleniumChrome)
   register_adapter(:rack_test, ShowMeTheCookies::RackTest)
   register_adapter(:poltergeist, ShowMeTheCookies::Poltergeist)
+  register_adapter(:phantomjs, ShowMeTheCookies::Poltergeist)
   register_adapter(:webkit, ShowMeTheCookies::Webkit)
   register_adapter(:webkit_debug, ShowMeTheCookies::Webkit)
 


### PR DESCRIPTION
We had issues with new SSL versions while using :poltergeist driver. Switching to :phantomjs driver seemed to fix.

I don't pretend to know what's happening under the hood. It might have something to do with how we have it configured. So feel free to ignore this if it doesn't make sense.