### PR TITLE
gemspec: remove unused directives

### DIFF
--- a/show_me_the_cookies.gemspec
+++ b/show_me_the_cookies.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |s|
   s.licenses = ["MIT"]
 
   s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.add_dependency('capybara', ['>= 2', '< 4'])
 end


### PR DESCRIPTION
This gem exposes no executables and test_files is not used by RubyGems.org.