### PR TITLE
Fix incompatibility with rack-test 2.0

### DIFF
--- a/lib/show_me_the_cookies/adapters/rack_test.rb
+++ b/lib/show_me_the_cookies/adapters/rack_test.rb
@@ -36,7 +36,7 @@ module ShowMeTheCookies
 
   private
     def cookie_jar
-      @rack_test_driver.browser.current_session.instance_variable_get(:@rack_mock_session).cookie_jar
+      @rack_test_driver.browser.current_session.cookie_jar
     end
 
     def cookies


### PR DESCRIPTION
This fixes the following error when calling `expire_cookies` with rack-test 2.0:

```
     NoMethodError:
       undefined method `cookie_jar' for nil:NilClass
             @rack_test_driver.browser.current_session.instance_variable_get(:@rack_mock_session).cookie_jar
                                                                                                 ^^^^^^^^^^^
```

See https://github.com/rack/rack-test/pull/297 for details about rack-test side changes.

I know that this gem has abandoned, however hope this helps for others.
