### PR TITLE
test: Configure RSpec to exclude top-level DSL

### DIFF
--- a/spec/shared_examples_for_api.rb
+++ b/spec/shared_examples_for_api.rb
@@ -1,4 +1,4 @@
-shared_examples "the API" do
+RSpec.shared_examples "the API" do
 
   describe "for getting cookie hashes" do
     describe "get_me_the_cookie" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ Capybara.app = Sinatra::Application
 require 'show_me_the_cookies'
 RSpec.configure do |config|
   config.include(ShowMeTheCookies, type: :feature)
+  config.disable_monkey_patching!
 end
 
 Capybara.server_port = 36363


### PR DESCRIPTION
Exclude the top-level DSL from Object and such; require the top-level
RSpec constructs to start with "RSpec.".

Huh. This ran to green completion on my machine.