### PR TITLE
Add Rails example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,29 @@ Then, in a feature spec using [Capybara](https://github.com/jnicklas/capybara):
     end
 
 
+## Rails
+
+include `ShowMeTheCookies` in your `ApplicationSystemTestCase`
+
+    class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+      include ShowMeTheCookies
+    end
+
+and use it in your system tests
+
+    require "application_system_test_case"
+
+    class LoginSystemTest < ApplicationSystemTestCase
+      test "user login is remembered across browser restarts" do
+        log_in_as_user
+        should_be_logged_in
+        #browser restart = session cookie is lost
+        expire_cookies
+        should_be_logged_in
+      end
+    end
+
+
 ## Cucumber
 
 


### PR DESCRIPTION
I'm about to upgrade a Rails 4 application and at least starting from Rails 6 it is required to include ShowMeTheCookies in your tests to use it. I updated the README with an example for Rails. :)